### PR TITLE
Replaced undocumented variant of an OR operator

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,8 +7,8 @@
         "php": "^7.2",
 
         "excelwebzone/recaptcha-bundle": "^1.5",
-        "friendsofsymfony/ckeditor-bundle": "^1.1|^2.1",
-        "knplabs/knp-gaufrette-bundle": "^0.5|^0.7",
+        "friendsofsymfony/ckeditor-bundle": "^1.1 || ^2.1",
+        "knplabs/knp-gaufrette-bundle": "^0.5 || ^0.7",
         "monolog/monolog": "~1.22",
         "sylius/grid-bundle": "^1.6",
         "sylius/resource-bundle": "^1.4",


### PR DESCRIPTION
More info here: https://github.com/composer/composer/issues/6755

This could be the cause of an issue for me trying to install SyliusBlogPlugin:

Problem 1
  - odiseoteam/sylius-blog-plugin[v1.2.0, ..., v1.2.2] require odiseoteam/blog-bundle ^1.1 -> satisfiable by odiseoteam/blog-bundle[v1.1.0, ..., v1.1.23].
  - odiseoteam/blog-bundle[v1.1.0, ..., v1.1.4] require friendsofsymfony/ckeditor-bundle ^1.1 -> found friendsofsymfony/ckeditor-bundle[1.1.0, 1.2.0, 1.2.1] but the package is fixed to 2.3.0 (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command.
  ...

Only ^1.1 for friendsofsymfony/ckeditor-bundle is recognized.