### PR TITLE
Resource Bundle Mapping Format need to be typed

### DIFF
--- a/src/OdiseoBlogBundle.php
+++ b/src/OdiseoBlogBundle.php
@@ -13,7 +13,7 @@ use Sylius\Bundle\ResourceBundle\SyliusResourceBundle;
  */
 final class OdiseoBlogBundle extends AbstractResourceBundle
 {
-    protected $mappingFormat = ResourceBundleInterface::MAPPING_YAML;
+    protected string $mappingFormat = ResourceBundleInterface::MAPPING_YAML;
 
     /**
      * {@inheritdoc}


### PR DESCRIPTION
Since last version of sylius 1.11.x, mapping format need to be typed.

Please merge and create tag v1.2.1